### PR TITLE
Export sqoop version variable for the after installation script

### DIFF
--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -15,6 +15,7 @@ if [ -f ./alti-sqoop-${SQOOP_VERSION}.x86_64.rpm ]; then
 fi
 
 export DATE_STRING=$(date "+%Y%m%d%H%M")
+export SQOOP_VERSION=${SQOOP_VERSION}
 
 # 2. build rpm
 fpm --verbose --maintainer support@altiscale.com --vendor Altiscale --provides alti-sqoop-${SQOOP_VERSION} -n alti-sqoop-${SQOOP_VERSION} -v ${ALTISCALE_RELEASE} --iteration ${DATE_STRING} --license "Apache License v2" --after-install create_link.sh -s dir -t rpm ./build/sqoop-${SQOOP_VERSION}=/opt


### PR DESCRIPTION
The package is installed on the dpci, but the linking is incorrect due to the not set SQOOP_VERSION env variable. This PR exports the mentioned variable to fix linking issue.